### PR TITLE
parallel to-trans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "buffer-redux"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,34 +119,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.16"
+name = "crossbeam-deque"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+checksum = "fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e3681d554572a651dda4186cd47240627c3d0114d45a95f6ad27f2f22e7548d"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
-name = "csv"
-version = "1.3.0"
+name = "either"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
-dependencies = [
- "memchr",
-]
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -153,12 +166,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "itoa"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "libc"
@@ -219,6 +226,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
+name = "rayon"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,12 +262,6 @@ checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "safemem"
@@ -337,12 +358,12 @@ dependencies = [
 
 [[package]]
 name = "to-trans"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
- "csv",
+ "memchr",
+ "rayon",
  "seq_io",
- "serde",
  "tempdir",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +178,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +200,16 @@ name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -361,7 +393,9 @@ name = "to-trans"
 version = "0.2.0"
 dependencies = [
  "clap",
+ "colored",
  "memchr",
+ "num_cpus",
  "rayon",
  "seq_io",
  "tempdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ seq_io = "0.3.2"
 tempdir = "0.3.7"
 memchr = "2.6.4"
 rayon = "1.5.1"
+num_cpus = "1.13.0"
+colored = "2.0.0"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "to-trans"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["alejandrogzi <jose.gonzalesdezavala1@unmsm.edu.pe>"]
 edition = "2021"
 license = "MIT"
@@ -13,11 +13,11 @@ categories = ["command-line-utilities", "science"]
 
 [dependencies]
 clap = { version = "4.4.2", features = ["derive"] }
-serde = { version = "^1", features = ["derive"] }
 thiserror = "1.0.50"
-csv = "1.1.6"
 seq_io = "0.3.2"
 tempdir = "0.3.7"
+memchr = "2.6.4"
+rayon = "1.5.1"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a command-line tool written in Rust designed to build a transcriptome
 by using a genome (.fa) and a gene model (.gtf/.gff).
 
 ## Usage
-``` bash
+``` plaintext
 High-performance transcriptome builder from fasta + GTF/GFF
 
 Usage: to-trans --fasta <FASTA> --gtf <GTF> [OPTIONS]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![version-badge](https://img.shields.io/badge/version-0.1.0-green)
+![version-badge](https://img.shields.io/badge/version-0.2.0-green)
 ![Crates.io](https://img.shields.io/crates/v/to-trans)
 ![GitHub](https://img.shields.io/github/license/alejandrogzi/noel?color=blue)
 

--- a/README.md
+++ b/README.md
@@ -10,23 +10,29 @@ This is a command-line tool written in Rust designed to build a transcriptome
 by using a genome (.fa) and a gene model (.gtf/.gff).
 
 ## Usage
-``` rust
+``` bash
 High-performance transcriptome builder from fasta + GTF/GFF
 
-Usage: to-trans [OPTIONS] --fasta <FASTA> --gtf <GTF>
+Usage: to-trans --fasta <FASTA> --gtf <GTF> [OPTIONS]
 
 --Arguments:
   -f, --fasta <FASTA>  Path to your .fa file
-  -g, --gtf <GTF>      Path to your .gtf file
+  -g, --gtf <GTF/GFF>      Path to your .gtf/.gff file
 
 Options:
   -m, --mode <MODE>      Feature to extract from GTF/GFF file (exon or CDS) [default: exon]
   -o, --out <OUT>      Path to output file [default: transcriptome.fa].
+  -t, --threads <THREADS>      Number of threads [default: max ncpus] 
   -h, --help           Print help
   -V, --version        Print version
 ```
 
 #### crate: [https://crates.io/crates/to-trans](https://crates.io/crates/to-trans)
+
+> What's new on v.0.2.0
+>
+> - Now to-trans is ~2-3s faster!
+> - A parallel approach is now the main algorithm to assemble transcript sequences
 
 > Work coming...
 >
@@ -50,6 +56,9 @@ to build to-trans, do:
 by default to-trans uses `exon` mode and sends the output to `./transcriptome.fa`
 
 ## Benchmark
+
+> Note that this benchamark is outdated. Now to-trans is ~2-3s faster!
+> For the human genome/gtf, to-trans takes 6 seconds to build a complete transcriptome, that is approximately x3 times faster than GFFRead!
 
 Besides some particular species, such as human (GRCh38) or mouse (GRCm39) 
 that have transcriptomes available, most of the animal kingdom does not 

--- a/src/gene.rs
+++ b/src/gene.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use crate::errors::*;
 use memchr::memchr;
 
@@ -17,7 +19,8 @@ impl GeneModel {
         let feature = fields[2];
 
         if feature == opt {
-            let id = mem_attr(fields[8]);
+            let id = de_attr(fields[8]).unwrap();
+            // let id = mem_attr(fields[8]);
             GeneModel {
                 chr: fields[0].to_string(),
                 feature: feature.to_string(),

--- a/src/gene.rs
+++ b/src/gene.rs
@@ -17,7 +17,6 @@ impl GeneModel {
         let feature = fields[2];
 
         if feature == opt {
-            // let id = de_attr(fields[8]).unwrap();
             let id = mem_attr(fields[8]);
             GeneModel {
                 chr: fields[0].to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,7 @@ pub use gene::*;
 pub mod fasta;
 pub use fasta::*;
 
+pub mod utils;
+pub use utils::*;
+
 pub mod errors;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@
 //! from a fasta file and a GTF/GFF file.
 //!
 //! Usage:
-//! to-trans <fasta> <gtf/gff> <opt> <output>
+//! to-trans <fasta> <gtf/gff> [<opt>] [<output>] [<threads>]
 
 use std::collections::HashMap;
 use std::fs::File;
@@ -12,6 +12,10 @@ use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 
 use rayon::prelude::*;
+
+use colored::Colorize;
+
+use num_cpus;
 
 use clap::{self, Parser};
 
@@ -35,24 +39,33 @@ const COMPLEMENT: [u8; 128] = {
 #[derive(Parser, Debug)]
 #[command(
     author = "Alejandro Gonzales-Irribarren",
-    version = "0.1.0",
+    version = "0.2.0",
     about = "High-performance transcriptome builder from fasta + GTF/GFF"
 )]
 struct Args {
     /// FASTA file
-    #[clap(short, long, help = "Path to .fa file")]
+    #[clap(short = 'f', long, help = "Path to .fa file", value_name = "FASTA")]
     fasta: PathBuf,
+
     /// GTF file
-    #[clap(short, long, help = "Path to annotation file")]
+    #[clap(
+        short = 'g',
+        long,
+        help = "Path to annotation file",
+        value_name = "GTF/GFF"
+    )]
     gtf: PathBuf,
+
     // Exon or CDS
     #[clap(
-        short,
+        short = 'm',
         long,
         help = "Feature to extract from GTF/GFF file (exon or CDS)",
-        default_value = "exon"
+        default_value = "exon",
+        value_name = "FEATURE"
     )]
     mode: String,
+
     /// Output file
     #[clap(
         short,
@@ -61,6 +74,16 @@ struct Args {
         help = "Path to output file"
     )]
     out: PathBuf,
+
+    /// Number of threads
+    #[clap(
+        short = 't',
+        long,
+        help = "Number of threads",
+        value_name = "THREADS",
+        default_value_t = num_cpus::get()
+    )]
+    threads: usize,
 }
 
 fn main() {
@@ -68,8 +91,53 @@ fn main() {
 
     let args = Args::parse();
 
-    let gtf = reader(&args.gtf).unwrap();
-    let records = parallel_parse(&gtf, &args.mode).unwrap();
+    if args.threads == 0 {
+        println!(
+            "{} {}",
+            "Error:".bright_red().bold(),
+            "Number of threads must be greater than 0!"
+        );
+        std::process::exit(1);
+    }
+
+    if std::fs::metadata(&args.fasta).unwrap().len() == 0 {
+        println!(
+            "{} {}",
+            "Error:".bright_red().bold(),
+            "Input file is empty!"
+        );
+        std::process::exit(1);
+    }
+
+    if args.fasta == args.out {
+        println!(
+            "{} {}",
+            "Error:".bright_red().bold(),
+            "Input and output files must be different!"
+        );
+        std::process::exit(1);
+    }
+
+    run(args);
+
+    let duration = time.elapsed();
+    println!("Elapsed: {:?}", duration);
+}
+
+fn run(args: Args) {
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(args.threads)
+        .build_global()
+        .unwrap();
+
+    let gtf = reader(&args.gtf).unwrap_or_else(|e| {
+        eprintln!("{} {}", "Error:".bright_red().bold(), e);
+        std::process::exit(1);
+    });
+    let records = parallel_parse(&gtf, &args.mode).unwrap_or_else(|e| {
+        eprintln!("{} {}", "Error:".bright_red().bold(), e);
+        std::process::exit(1);
+    });
     let seqs = Fasta::read(&args.fasta).unwrap().records;
     let mut writer = BufWriter::new(File::create(args.out).unwrap());
 
@@ -77,7 +145,7 @@ fn main() {
     let transcripts: HashMap<String, (String, String, Vec<u32>, Vec<u32>)> = records
         .into_par_iter()
         .fold(
-            || HashMap::new(), // Create an empty local HashMap as the accumulator.
+            || HashMap::new(), // local accumulator [per thread]
             |mut local_transcripts, record| {
                 let (chr, strand, start, end, transcript) = (
                     record.chr,
@@ -89,7 +157,7 @@ fn main() {
 
                 let entry = local_transcripts
                     .entry(transcript)
-                    .or_insert_with(|| (chr.clone(), strand.clone(), Vec::new(), Vec::new()));
+                    .or_insert_with(|| (chr, strand, Vec::new(), Vec::new()));
                 entry.2.push(start);
                 entry.3.push(end);
 
@@ -97,9 +165,9 @@ fn main() {
             },
         )
         .reduce(
-            || HashMap::new(), // Create an empty HashMap for the reducing step.
+            || HashMap::new(),
             |mut combined_transcripts, local_transcripts| {
-                // Merge the local accumulator into the combined one.
+                // merge local accs
                 for (transcript, (chr, strand, starts, ends)) in local_transcripts {
                     let combined_entry = combined_transcripts
                         .entry(transcript)
@@ -114,38 +182,35 @@ fn main() {
     for (transcript, (chr, strand, mut starts, mut ends)) in transcripts {
         if !transcript.is_empty() {
             let mut seq = String::new();
+            let mut process_parts = |starts: &mut Vec<u32>, ends: &mut Vec<u32>| {
+                for (i, &start) in starts.iter().enumerate() {
+                    let end = ends[i];
+                    if let Some(part) = get_sequence(&seqs, &chr, start, end, &strand) {
+                        seq.push_str(&String::from_utf8(part).expect("Invalid UTF-8 sequence"));
+                    }
+                }
+            };
+
             match strand.as_str() {
                 "+" => {
                     starts.sort_unstable();
                     ends.sort_unstable();
 
-                    for (i, &start) in starts.iter().enumerate() {
-                        let end = ends[i];
-                        if let Some(part) = get_sequence(&seqs, &chr, start, end, &strand) {
-                            seq.push_str(&String::from_utf8(part).unwrap());
-                        }
-                    }
-                    writeln!(writer, ">{}\n{}", transcript, seq).unwrap();
+                    process_parts(&mut starts, &mut ends);
                 }
                 "-" => {
                     starts.sort_unstable_by(|a, b| b.cmp(a));
                     ends.sort_unstable_by(|a, b| b.cmp(a));
 
-                    for (i, &start) in starts.iter().enumerate() {
-                        let end = ends[i];
-                        if let Some(part) = get_sequence(&seqs, &chr, start, end, &strand) {
-                            seq.push_str(&String::from_utf8(part).unwrap());
-                        }
-                    }
-                    writeln!(writer, ">{}\n{}", transcript, seq).unwrap();
+                    process_parts(&mut starts, &mut ends);
                 }
                 _ => (),
             }
+            if let Err(e) = writeln!(writer, ">{}\n{}", transcript, seq) {
+                eprintln!("Failed to write sequence {}: {}", transcript, e);
+            }
         }
     }
-
-    let duration = time.elapsed();
-    println!("Elapsed: {:?}", duration);
 }
 
 fn get_sequence(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,25 @@
+use std::fs::File;
+use std::io::{self, Read};
+use std::path::PathBuf;
+
+use crate::errors::*;
+use crate::gene::GeneModel;
+
+use rayon::prelude::*;
+
+pub fn parallel_parse<'a>(s: &'a str, opt: &str) -> Result<Vec<GeneModel>> {
+    let records = s
+        .par_lines()
+        .filter(|line| !line.starts_with("#"))
+        .map(|line| GeneModel::parse(line, opt))
+        .collect::<Vec<GeneModel>>();
+
+    return Ok(records);
+}
+
+pub fn reader(file: &PathBuf) -> io::Result<String> {
+    let mut file = File::open(file)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    Ok(contents)
+}


### PR DESCRIPTION
This PR introduces a parallel algorithm to assemble transcript sequences. With this new approach, to-trans achieves a reduction of ~2-3s, reducing computation times x3 compared with GFFRead. The GeneModel struct has been re-structured. now each line is parsed separately instead of looping and building a unique HashMap. In this release, to-trans will not use memchr to extract transcript_ids, since caused some overhead compared with the local impl.